### PR TITLE
feat(fps): on-device FPS/frametime overlay + perf log (HOM-165)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ include(generated/rexglue.cmake)
 set(GE_SOURCES
     src/main.cpp
     src/ge_hooks.cpp
+    src/ge_fps.cpp
     src/ge_menu.cpp
     src/ge_postfx.cpp
     src/ge_username.cpp

--- a/src/ge_app.h
+++ b/src/ge_app.h
@@ -16,6 +16,7 @@
 
 #include <string>
 
+#include "ge_fps.h"
 #include "ge_menu.h"
 #include "ge_postfx.h"
 
@@ -61,6 +62,7 @@ class GeApp : public rex::ReXApp {
     rex::ui::RegisterBind("bind_pause_menu", "Escape", "Pause menu",
                           [this] { TogglePauseMenu(); });
     postfx_ = std::make_unique<ge::PostFxOverlay>(drawer);
+    fps_overlay_ = std::make_unique<ge::FpsOverlay>(drawer);
     // Username/server are set in the ONLINE pause-menu tab now -- no first-boot
     // prompt. They apply on the Save & Restart the ONLINE tab triggers.
   }
@@ -75,6 +77,7 @@ class GeApp : public rex::ReXApp {
       menu_ = nullptr;
     }
     postfx_.reset();
+    fps_overlay_.reset();
   }
 
  private:
@@ -125,4 +128,5 @@ class GeApp : public rex::ReXApp {
 
   GeMenuDialog* menu_ = nullptr;  // non-owning; self-deletes via the drawer
   std::unique_ptr<ge::PostFxOverlay> postfx_;       // always-on filter layer
+  std::unique_ptr<ge::FpsOverlay>    fps_overlay_;  // FPS/frametime corner HUD
 };

--- a/src/ge_fps.cpp
+++ b/src/ge_fps.cpp
@@ -1,0 +1,161 @@
+// ge - ReXGlue Recompiled Project
+//
+// Lightweight FPS/frametime corner overlay + optional perf log.
+// See ge_fps.h for the public API.
+
+#include "ge_fps.h"
+
+#include <rex/cvar.h>
+#include <rex/hook.h>  // REXKRNL_INFO
+
+#include <imgui.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdio>
+
+// Gate the corner overlay: default OFF so it doesn't intrude on normal play.
+// Toggle from the VIDEO tab of the ESC pause menu, or set ge_show_fps=true in
+// ge.toml. No rebuild required -- the cvar is hot-reloaded.
+REXCVAR_DEFINE_BOOL(ge_show_fps, false, "Video",
+                    "GoldenEye: show FPS/frametime corner overlay (top-left HUD)");
+
+// Optional perf log: writes P50/P90/P99 frametime percentiles to ge.log ~once/sec.
+// Useful for offline before/after comparison across perf patches.
+REXCVAR_DEFINE_BOOL(ge_perf_log, false, "Video",
+                    "GoldenEye: log frametime percentiles to ge.log ~once/second");
+
+namespace ge {
+
+namespace {
+
+// Xbox 360 PPC timebase frequency (~49.875 MHz, same source as mftb).
+constexpr float kTbHz = 49875000.0f;
+
+// Circular buffer of raw REX_QUERY_TIMEBASE() ticks at each guest present.
+// 128 slots ~ 2 seconds at 60 fps. Ring slots are individually atomic; the
+// head index is written after the slot, so a racing reader may see a stale
+// slot -- tolerated for a diagnostic display.
+constexpr int kRingSize = 128;
+std::atomic<uint32_t> g_ring[kRingSize];
+std::atomic<int>      g_head{0};   // next write slot
+std::atomic<int>      g_count{0};  // valid entries clamped to kRingSize
+
+// Timebase tick of the last perf-log line (for ~1s throttle).
+std::atomic<uint32_t> g_last_log_tb{0};
+
+// Collect up to `max_deltas` frametime values (ms) from the ring into `out`.
+// Returns the count written. Skips any delta that looks obviously wrong
+// (0 ticks or > 1 second).
+int CollectDeltas(float* out, int max_deltas) {
+  const int n = g_count.load(std::memory_order_relaxed);
+  if (n < 2) return 0;
+  const int head = g_head.load(std::memory_order_relaxed);
+  const int pairs = std::min(n - 1, kRingSize - 1);
+  int nd = 0;
+  for (int i = 0; i < pairs && nd < max_deltas; ++i) {
+    const int idx_new = (head - 1 - i + kRingSize * 2) % kRingSize;
+    const int idx_old = (head - 2 - i + kRingSize * 2) % kRingSize;
+    const uint32_t tnew = g_ring[idx_new].load(std::memory_order_relaxed);
+    const uint32_t told = g_ring[idx_old].load(std::memory_order_relaxed);
+    const uint32_t dt = tnew - told;
+    if (dt == 0 || dt > 49875000u) continue;  // skip zeros and > 1s gaps
+    out[nd++] = static_cast<float>(dt) * 1000.0f / kTbHz;
+  }
+  return nd;
+}
+
+}  // namespace
+
+void FpsRecordPresent(uint32_t tb) {
+  const int h = g_head.load(std::memory_order_relaxed);
+  g_ring[h].store(tb, std::memory_order_relaxed);
+  g_head.store((h + 1) % kRingSize, std::memory_order_relaxed);
+  const int cnt = g_count.load(std::memory_order_relaxed);
+  if (cnt < kRingSize) g_count.store(cnt + 1, std::memory_order_relaxed);
+
+  // Perf log: emit percentile summary ~once/second when ge_perf_log is on.
+  if (!REXCVAR_GET(ge_perf_log)) return;
+  const uint32_t last_log = g_last_log_tb.load(std::memory_order_relaxed);
+  if ((uint32_t)(tb - last_log) < 49875000u) return;  // < ~1 second
+  g_last_log_tb.store(tb, std::memory_order_relaxed);
+
+  float deltas[kRingSize - 1];
+  const int nd = CollectDeltas(deltas, kRingSize - 1);
+  if (nd < 4) return;
+
+  std::sort(deltas, deltas + nd);
+  float sum = 0.0f;
+  for (int i = 0; i < nd; ++i) sum += deltas[i];
+  const float avg = sum / static_cast<float>(nd);
+  const float p50 = deltas[nd / 2];
+  const float p90 = deltas[(nd * 9) / 10];
+  const float p99 = deltas[(nd * 99) / 100];
+  const float fps_avg = avg > 0.0f ? 1000.0f / avg : 0.0f;
+  REXKRNL_INFO(
+      "GE PERF: frames={} avg_fps={:.1f} avg={:.2f}ms p50={:.2f}ms p90={:.2f}ms p99={:.2f}ms",
+      nd, fps_avg, avg, p50, p90, p99);
+}
+
+FpsOverlay::FpsOverlay(rex::ui::ImGuiDrawer* drawer) : rex::ui::ImGuiDialog(drawer) {}
+FpsOverlay::~FpsOverlay() = default;
+
+void FpsOverlay::OnDraw(ImGuiIO& /*io*/) {
+  if (!REXCVAR_GET(ge_show_fps)) return;
+
+  // Read up to 64 recent deltas (about 1 second at 60 fps) for min/avg/max.
+  // The last delta in the array (index 0) is the most recent frametime.
+  float deltas[64];
+  const int nd = CollectDeltas(deltas, 64);
+  if (nd == 0) return;
+
+  const float ft_last = deltas[0];
+  const float fps = ft_last > 0.0f ? 1000.0f / ft_last : 0.0f;
+
+  float mn = ft_last, mx = ft_last, sum = 0.0f;
+  for (int i = 0; i < nd; ++i) {
+    if (deltas[i] < mn) mn = deltas[i];
+    if (deltas[i] > mx) mx = deltas[i];
+    sum += deltas[i];
+  }
+  const float avg = sum / static_cast<float>(nd);
+
+  // Small semi-transparent window pinned to the top-left corner.
+  ImGui::SetNextWindowPos(ImVec2(10.0f, 10.0f), ImGuiCond_Always);
+  ImGui::SetNextWindowBgAlpha(0.65f);
+  constexpr ImGuiWindowFlags kFlags =
+      ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_AlwaysAutoResize |
+      ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_NoFocusOnAppearing |
+      ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoInputs |
+      ImGuiWindowFlags_NoBringToFrontOnFocus;
+
+  if (!ImGui::Begin("##ge_fps_hud", nullptr, kFlags)) {
+    ImGui::End();
+    return;
+  }
+
+  ImGui::SetWindowFontScale(1.3f);
+
+  char buf[64];
+  std::snprintf(buf, sizeof(buf), "FPS  %5.1f", fps);
+  ImGui::Text("%s", buf);
+
+  std::snprintf(buf, sizeof(buf), " ft  %5.2f ms", ft_last);
+  ImGui::Text("%s", buf);
+
+  if (nd >= 2) {
+    std::snprintf(buf, sizeof(buf), "min  %5.2f ms", mn);
+    ImGui::TextColored(ImVec4(0.4f, 1.0f, 0.4f, 1.0f), "%s", buf);
+
+    std::snprintf(buf, sizeof(buf), "avg  %5.2f ms", avg);
+    ImGui::Text("%s", buf);
+
+    std::snprintf(buf, sizeof(buf), "max  %5.2f ms", mx);
+    ImGui::TextColored(ImVec4(1.0f, 0.55f, 0.35f, 1.0f), "%s", buf);
+  }
+
+  ImGui::SetWindowFontScale(1.0f);
+  ImGui::End();
+}
+
+}  // namespace ge

--- a/src/ge_fps.h
+++ b/src/ge_fps.h
@@ -1,0 +1,38 @@
+// ge - ReXGlue Recompiled Project
+//
+// Lightweight FPS / frametime corner overlay and perf log.
+//
+// FpsRecordPresent() is called once per guest present (from ge_diag_vdswap)
+// with the current REX_QUERY_TIMEBASE() tick. FpsOverlay is an always-on
+// ImGui dialog that reads the ring buffer and draws a small HUD.
+//
+// Gated behind ge_show_fps (default off). ge_perf_log (default off) writes
+// frametime percentiles to ge.log ~once/sec for offline before/after comparison.
+//
+// This file is yours to edit. 'rexglue migrate' will NOT overwrite it.
+
+#pragma once
+
+#include <rex/ui/imgui_dialog.h>
+
+#include <cstdint>
+
+namespace ge {
+
+// Record a present timestamp (REX_QUERY_TIMEBASE() tick) into the ring buffer.
+// Called from ge_diag_vdswap() -- the natural per-present hook point.
+// Thread-safe; relaxed atomics (diagnostic accuracy is sufficient).
+void FpsRecordPresent(uint32_t tb);
+
+// Corner HUD overlay: FPS, frametime (ms), rolling min/avg/max.
+// Created once at startup alongside PostFxOverlay; renders when ge_show_fps=true.
+class FpsOverlay : public rex::ui::ImGuiDialog {
+ public:
+  explicit FpsOverlay(rex::ui::ImGuiDrawer* drawer);
+  ~FpsOverlay() override;
+
+ protected:
+  void OnDraw(ImGuiIO& io) override;
+};
+
+}  // namespace ge

--- a/src/ge_hooks.cpp
+++ b/src/ge_hooks.cpp
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <cstring>
 
+#include "ge_fps.h"    // FpsRecordPresent (per-present frametime sampling)
 #include "ge_init.h"   // PPCRegister/PPCContext + generated function decls
 #include <rex/cvar.h>  // REXCVAR_DEFINE_BOOL / REXCVAR_GET (ge_freeze_diag)
 #include <rex/hook.h>  // ThreadState, kernel_state, memory
@@ -594,8 +595,10 @@ void ge_diag_vdswap(PPCRegister& r31, PPCRegister& r30) {
   uint32_t a1 = r31.u32;
   auto* cpp = ge_cp();
   uint32_t cpc = cpp ? cpp->counter() : 0;
+  const uint32_t tb_now = (uint32_t)REX_QUERY_TIMEBASE();
   g_present_cpcnt.store(cpc, std::memory_order_relaxed);
-  g_present_tb.store((uint32_t)REX_QUERY_TIMEBASE(), std::memory_order_relaxed);
+  g_present_tb.store(tb_now, std::memory_order_relaxed);
+  ge::FpsRecordPresent(tb_now);  // feed the frametime ring buffer
 
   static uint32_t n = 0;                       // throttled fps heartbeat (diag only)
   if ((n++ & 0x3F) == 0 && REXCVAR_GET(ge_freeze_diag))

--- a/src/ge_menu.cpp
+++ b/src/ge_menu.cpp
@@ -330,6 +330,25 @@ void GeMenuDialog::DrawContent(ImGuiIO& /*io*/) {
                          "(fixes picture freeze; higher = fewer freezes, more lag)");
 
       ImGui::Spacing();
+
+      // --- FPS/Frametime overlay ---
+      bool show_fps = GetCvarB("ge_show_fps");
+      if (ImGui::Checkbox("Show FPS Overlay", &show_fps)) {
+        SetCvarB("ge_show_fps", show_fps);
+        if (callbacks_.persist_config) callbacks_.persist_config();
+      }
+      ImGui::TextColored(ImColor(kInkDim), "(FPS + frametime HUD in top-left corner)");
+
+      ImGui::Spacing();
+
+      bool perf_log = GetCvarB("ge_perf_log");
+      if (ImGui::Checkbox("Perf Log (1/sec to ge.log)", &perf_log)) {
+        SetCvarB("ge_perf_log", perf_log);
+        if (callbacks_.persist_config) callbacks_.persist_config();
+      }
+      ImGui::TextColored(ImColor(kInkDim), "(frametime percentiles; use for before/after comparison)");
+
+      ImGui::Spacing();
       ImGui::Separator();
       ImGui::Spacing();
 


### PR DESCRIPTION
## Summary

- Adds `ge_fps.h` / `ge_fps.cpp`: a 128-slot atomic ring buffer fed by `ge_diag_vdswap()` (one tick per guest present), plus an `FpsOverlay` ImGui dialog that reads it.
- **Corner HUD** (`ge_show_fps`, default OFF): shows current FPS, last frametime (ms), and rolling min/avg/max over the last 64 frames. No per-frame allocation; no locking.
- **Perf log** (`ge_perf_log`, default OFF): emits P50/P90/P99 frametime percentiles to `ge.log` ~once/second for offline before/after comparison across perf patches.
- Both cvars are togglable live from the **VIDEO tab** of the ESC pause menu and persisted to `ge.toml`.
- `ge_diag_vdswap`'s existing `"GEGPU present#"` heartbeat line is untouched (load-bearing for the Java auto-retry path).

## How to toggle

```
# In-game: ESC → VIDEO → "Show FPS Overlay" checkbox
# Or in ge.toml:
ge_show_fps = true
ge_perf_log = true
```

## Test plan

- [ ] Build for Android (`cmake --preset android-arm64`) and confirm no compile errors
- [ ] Run on device; enable `ge_show_fps` via menu — verify corner HUD appears with FPS / ft / min / avg / max
- [ ] Disable `ge_show_fps` — confirm HUD disappears with no visual artifacts
- [ ] Enable `ge_perf_log` — confirm `ge.log` receives periodic `GE PERF:` lines (~once/sec) during gameplay
- [ ] Confirm `ge_diag_vdswap`'s `"GEGPU present#"` line still fires when `ge_freeze_diag=true`
- [ ] Confirm toggles survive an ESC menu save/reload cycle (cvar persisted to `ge.toml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)