### PR TITLE
perf(android): optimized release build + split debug/release packaging

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -20,8 +20,7 @@ android {
 
         externalNativeBuild {
             cmake {
-                arguments "-DREXSDK_DIR=${file(rootProject.findProperty('rexSdkDir') ?: '../../GoldenEye-Recomp-rexglue').absolutePath}",
-                          '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+                arguments "-DREXSDK_DIR=${file(rootProject.findProperty('rexSdkDir') ?: '../../GoldenEye-Recomp-rexglue').absolutePath}"
                 // C++23; libc++ jthread/stop_token need the experimental library.
                 cppFlags '-std=c++23', '-fexperimental-library'
             }
@@ -42,8 +41,29 @@ android {
     // AGP picks up the target `ge` and its shared-lib dependencies automatically.
 
     buildTypes {
+        debug {
+            debuggable true
+            jniDebuggable true
+            // Keep extractNativeLibs=true so simpleperf / run-as can access .so files on-disk.
+            manifestPlaceholders = [extractNativeLibs: 'true']
+            externalNativeBuild {
+                cmake {
+                    arguments '-DCMAKE_BUILD_TYPE=Debug'
+                }
+            }
+        }
         release {
+            debuggable false
             minifyEnabled false
+            // Uncompressed libs in APK: loaded directly via mmap, no disk extraction.
+            manifestPlaceholders = [extractNativeLibs: 'false']
+            externalNativeBuild {
+                cmake {
+                    // RelWithDebInfo now compiles at -O3 -DNDEBUG -g (see rexglue CMakeLists.txt).
+                    // Keeps DWARF symbols in the .so for symbolication; strip is done at APK packaging.
+                    arguments '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+                }
+            }
         }
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -20,8 +20,7 @@
     <application
         android:allowBackup="false"
         android:label="GoldenEye 007"
-        android:debuggable="true"
-        android:extractNativeLibs="true"
+        android:extractNativeLibs="${extractNativeLibs}"
         android:resizeableActivity="false"
         android:hasCode="true">
 


### PR DESCRIPTION
## Summary

- **Before**: every variant used `-DCMAKE_BUILD_TYPE=RelWithDebInfo` (compiled at `-O2`, asserts live). The APK always had `android:debuggable="true"` and `android:extractNativeLibs="true"`.
- **release** build type now passes `-DCMAKE_BUILD_TYPE=RelWithDebInfo` (which after [rexglue#4](https://github.com/jeffory/GoldenEye-Recomp-rexglue/pull/4) compiles at `-O3 -DNDEBUG -g`), `debuggable=false`, `extractNativeLibs=false` (libs are mmap'd directly from the APK — no disk extraction, faster cold-start).
- **debug** build type passes `-DCMAKE_BUILD_TYPE=Debug` (`-O0 -g`, asserts on), `debuggable=true`, `jniDebuggable=true`, `extractNativeLibs=true` (simpleperf and `run-as` can reach `.so` files on-disk for the boot-race / freeze-diag tooling).
- `android:debuggable` removed from the manifest (AGP injects it per variant; hardcoding `true` was overriding release builds).
- `android:extractNativeLibs` converted to a `${extractNativeLibs}` manifest placeholder, resolved per build type.

## Preserved behaviour

- `GoldenEyeActivity` auto-retry watchdog, loading overlay, and the `ge.log` / `"GEGPU present#"` detection path are unaffected.
- Debug builds remain fully debuggable and profilable with simpleperf.

## Test plan

- [ ] `assembleRelease`: confirm APK has `android:debuggable="false"`, `android:extractNativeLibs="false"`, and that libge.so contains `-O3 -DNDEBUG` flags (check `compile_commands.json`).
- [ ] `assembleDebug`: confirm `android:debuggable="true"`, `android:extractNativeLibs="true"`, libs extracted correctly on-device.
- [ ] Boot + auto-retry watchdog still works in release APK (no regression on the `GEGPU present#` path).
- [ ] On-device FPS measurement to confirm perf improvement.

**Depends on**: jeffory/GoldenEye-Recomp-rexglue#4 (SDK CMakeLists RelWithDebInfo flags) — merge that PR first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)